### PR TITLE
Fix cycle dependency error on destroy (#1)

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -29,44 +29,6 @@ resource "digitalocean_droplet" "node" {
     ]
   }
 
-  # Handle clean up / destroy worker node
-  # drain worker on destroy
-  provisioner "remote-exec" {
-    when = "destroy"
-
-    inline = [
-      "docker node update --availability drain ${self.name}",
-    ]
-
-    on_failure = "continue"
-
-    connection {
-      type        = "ssh"
-      user        = "${var.provision_user}"
-      private_key = "${file("${var.provision_ssh_key}")}"
-      host        = "${var.manager_public_ip}"
-    }
-  }
-
-  # remove node on destroy
-  provisioner "remote-exec" {
-    when = "destroy"
-
-    inline = [
-      "docker node rm --force ${self.name}",
-    ]
-
-    on_failure = "continue"
-
-    connection {
-      type        = "ssh"
-      user        = "${var.provision_user}"
-      private_key = "${file("${var.provision_ssh_key}")}"
-      host        = "${var.manager_public_ip}"
-    }
-  }
-
-  # leave swarm on destroy
   provisioner "remote-exec" {
     when = "destroy"
 


### PR DESCRIPTION
- Removes unnecessary code and steps, just leaving the cluster using
swarm leave should be sufficient

Fix #1, and closes thojkooi/terraform-digitalocean-docker-swarm-mode#8