### PR TITLE
Improve joining workers to swarm cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Terraform module to provision a Docker Swarm mode worker nodes to join a cluster
 
 ## Requirements
 
-- Terraform >= 0.11.2
+- Terraform >= 0.11.7
 - Digitalocean account / API token with write access
 - SSH Keys added to your DigitalOcean account
 
@@ -19,7 +19,6 @@ Terraform module to provision a Docker Swarm mode worker nodes to join a cluster
 
 module "workers" {
   source   = "github.com/thojkooi/terraform-digitalocean-swarm-workers"
-  do_token = "${var.do_token}"
 
   size            = "s-1vcpu-1gb"
   name            = "web"
@@ -27,7 +26,6 @@ module "workers" {
   domain          = "example.com"
   total_instances = 3
 
-  manager_public_ip  = "${element(digitalocean_droplet.manager.*.ipv4_address, 0)}"
   manager_private_ip = "${element(digitalocean_droplet.manager.*.ipv4_address_private, 0)}"
   join_token         = "${lookup(data.external.swarm_tokens.result, "worker")}"
 

--- a/scripts/join.sh
+++ b/scripts/join.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Wait until Docker is running correctly
+while [ -z "$(${docker_cmd} info | grep CPUs)" ]; do
+  echo Waiting for Docker to start...
+  sleep 2
+done
+
+# Join cluster
+${docker_cmd} swarm join --token $1 \
+  --availability ${availability} ${manager_private_ip}:2377

--- a/variables.tf
+++ b/variables.tf
@@ -1,17 +1,9 @@
-variable "do_token" {
-  description = "DigitalOcean API token with read/write permissions"
-}
-
 variable "domain" {
   description = "Domain name used in droplet hostnames, e.g example.com"
 }
 
 variable "join_token" {
   description = "Join token for the nodes"
-}
-
-variable "manager_public_ip" {
-  description = "Public ip adress of a manager node, used to unregister a node in the Docker swarm cluster on destroy"
 }
 
 variable "manager_private_ip" {
@@ -66,6 +58,11 @@ variable "name" {
 variable "user_data" {
   description = "User data content for worker nodes. Use this for installing a configuration management tool, such as Puppet or installing Docker"
   default     = ""
+}
+
+variable "docker_cmd" {
+  description = "Docker command"
+  default     = "sudo docker"
 }
 
 variable "tags" {


### PR DESCRIPTION
- Add option to change the docker command
- Improve scripts to join worker nodes to cluster
- Remove need to pass `do_token` variable. Now instead uses the provider passed to the module
- Remove unused variable `manager_public_ip`
